### PR TITLE
Fix fs promise constant access

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const fs = require('fs').promises;
+const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 const spawnSync = require('cross-spawn').sync;
@@ -58,7 +58,7 @@ const argv = yargs(process.argv.slice(2))
 
     let packageJsonExists = false
     try {
-      await fs.access(path.join(result.appRoot, "package.json"), fs.constants.F_OK);
+      await fs.promises.access(path.join(result.appRoot, "package.json"), fs.constants.F_OK);
       packageJsonExists = true
     } catch {
       // package.json doesn't exist in kit - it is OK, we just don't run npm install


### PR DESCRIPTION
Kontrola souboru package.json padala na chybce s `fs.constants`, které nejsou ve `fs.promises`, ale pouze v `fs`. Import a kód upraven tak, aby se zachovala funkcionalita, ale opravil se přístup k vlastnostem.